### PR TITLE
save user token using local storage

### DIFF
--- a/main.js
+++ b/main.js
@@ -163,7 +163,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-  
+
   const nameInput = document.getElementById('name');
   const msgInput = document.getElementById('msg');
 
@@ -172,14 +172,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const savedData = localStorage.getItem(STORAGE_KEY);
     if (savedData) {
-      try {
-        const parsedData = JSON.parse(savedData);
-        nameInput.value = parsedData.name || '';
-        emailInput.value = parsedData.email || '';
-        msgInput.value = parsedData.message || '';
-      } catch (error) {
-        console.error('Error parsing data from localStorage', error);
-      }
+      const parsedData = JSON.parse(savedData);
+      nameInput.value = parsedData.name || '';
+      emailInput.value = parsedData.email || '';
+      msgInput.value = parsedData.message || '';
     }
 
     contactForm.addEventListener('input', () => {

--- a/main.js
+++ b/main.js
@@ -163,4 +163,38 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+  
+  const nameInput = document.getElementById('name');
+  const msgInput = document.getElementById('msg');
+
+  if (contactForm && nameInput && emailInput && msgInput) {
+    const STORAGE_KEY = 'portfolio_contact_form_data';
+
+    const savedData = localStorage.getItem(STORAGE_KEY);
+    if (savedData) {
+      try {
+        const parsedData = JSON.parse(savedData);
+        nameInput.value = parsedData.name || '';
+        emailInput.value = parsedData.email || '';
+        msgInput.value = parsedData.message || '';
+      } catch (error) {
+        console.error('Error parsing data from localStorage', error);
+      }
+    }
+
+    contactForm.addEventListener('input', () => {
+      const formData = {
+        name: nameInput.value,
+        email: emailInput.value,
+        message: msgInput.value,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(formData));
+    });
+
+    contactForm.addEventListener('submit', () => {
+      if (emailInput.value === emailInput.value.toLowerCase()) {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
Adds `localStorage` functionality to save and persist data across browser sessions.

## Key Changes
- Implemented `localStorage.setItem` to save data.
- Implemented `localStorage.getItem` to retrieve data on page load.

## How to Test
1. Perform the action that saves data.
2. Refresh the browser page.
3. Verify that the data is successfully retrieved and restored.
